### PR TITLE
Fix profile endpoint and tasks list

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -63,3 +63,9 @@ async def get_current_user(
     if not user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
     return user
+
+
+@router.get("/me", response_model=UserOut)
+async def read_current_user(current_user: Any = Depends(get_current_user)) -> Any:
+    """Devuelve el usuario autenticado actual."""
+    return id_to_str(current_user)

--- a/frontend/src/components/TaskList.js
+++ b/frontend/src/components/TaskList.js
@@ -7,7 +7,7 @@ function TaskList({ onEdit }) {
 
   const fetchTasks = async () => {
     const res = await api.get('/tasks');
-    setTasks(res.data);
+    setTasks(res.data.tasks);
   };
 
   useEffect(() => { fetchTasks(); }, []);


### PR DESCRIPTION
## Summary
- return tasks list array correctly in React frontend
- add `/users/me` route for user profile

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68642252a868832185ada58cb397b117